### PR TITLE
Update LB_QUEUED.tmSnippet

### DIFF
--- a/Snippets/LB_QUEUED.tmSnippet
+++ b/Snippets/LB_QUEUED.tmSnippet
@@ -8,6 +8,8 @@
 }</string>
 	<key>name</key>
 	<string>LB_QUEUED</string>
+	<key>tabTrigger</key>
+	<string>when</string>
 	<key>uuid</key>
 	<string>0192EF00-F3C1-4259-B252-327986FD4540</string>
 </dict>


### PR DESCRIPTION
snippet conversion for vs code failed Couse of non existent tabTrigger value.
